### PR TITLE
Updated path to RStudio Archives

### DIFF
--- a/ARM-RStudio.sh
+++ b/ARM-RStudio.sh
@@ -37,10 +37,10 @@ BUILD_DIR="${HOME}"
 
 echo "Downloading RStudio ${VERS}"
 cd "${BUILD_DIR}"
-wget "https://github.com/rstudio/rstudio/archive/${VERS}"
+wget "https://github.com/rstudio/rstudio/archive/refs/tags/${VERS}.tar.gz"
 mkdir "rstudio-${VERS}"
-tar xvf "${VERS}" -C "rstudio-${VERS}" --strip-components 1
-rm "${VERS}"
+tar xvf "${VERS}.tar.gz" -C "rstudio-${VERS}" --strip-components 1
+rm "${VERS}.tar.gz"
 
 #Run common environment preparation scripts
 cd "${BUILD_DIR}/rstudio-${VERS}/dependencies/common/"


### PR DESCRIPTION
The previous link was broken as github has changed the way directory paths for archived versions are stored.
Adding /refs/tags/ to the PATH in-between /archive/ and ${VERS}.